### PR TITLE
Features/status test prediction

### DIFF
--- a/HealCommClassic.lua
+++ b/HealCommClassic.lua
@@ -269,14 +269,14 @@ function CompactUnitFrame_UpdateStatusTextNew(frame)
 			return
 		end
 
-		-- New behavior with option turned onwww
+		-- New behavior with option turned on
 		if (healthDelta > 0) then
 			frame.statusText:SetTextColor(HealCommSettings.healColor.red, HealCommSettings.healColor.green, HealCommSettings.healColor.blue)
 		elseif ( healthDelta < 0 ) then
 			frame.statusText:SetTextColor(0.5, 0.5, 0.5)
 		end
 
-		if (healthDelta == 0) then
+		if (healthLost == 0) then
 			frame.statusText:Hide();
 		else
 			frame.statusText:SetFormattedText("%d", healthDelta);

--- a/HealCommClassic.lua
+++ b/HealCommClassic.lua
@@ -272,7 +272,7 @@ function CompactUnitFrame_UpdateStatusTextNew(frame)
 		-- New behavior with option turned on
 		if (healthDelta > 0) then
 			frame.statusText:SetTextColor(HealCommSettings.healColor.red, HealCommSettings.healColor.green, HealCommSettings.healColor.blue)
-		elseif ( healthDelta < 0 ) then
+		else
 			frame.statusText:SetTextColor(0.5, 0.5, 0.5)
 		end
 


### PR DESCRIPTION
Showing 0 while incoming heals equals health lost is valid behavior.
Use healthLost over healthDelta to determine if to show health status text. 

Any thoughts?

We could compare to Luna Unit frame for exact expected results!

Cheers.